### PR TITLE
fix jsonld randomish parsing on fetch

### DIFF
--- a/src/helpers/DataClient.js
+++ b/src/helpers/DataClient.js
@@ -13,9 +13,9 @@ export function getPage(path) {
       return resolve(toto);
     }
     const request = superagent.get(formatUrl(path));
-    request.end((err, { body, text } = {}) => {
-      if (err) return reject(body || err);
-      return resolve(JSON.parse(body || text));
+    request.end((err, { text } = {}) => {
+      if (err) return reject(err);
+      return resolve(JSON.parse(text));
     });
   });
 }


### PR DESCRIPTION
close #16.

Didn’t find a way to serve right content type with webpack dev server. But this fix should leverage a more consistent behavior when fetching jsonld docs.
